### PR TITLE
feat. soft deleting books and users

### DIFF
--- a/sql/02_EfiLibrary.sql
+++ b/sql/02_EfiLibrary.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS `library_user` (
   `username` varchar(50) NOT NULL,
   `passw` varchar(150) NOT NULL,
   `administrator` tinyint(1) DEFAULT NULL,
+  `deleted` tinyint(1) DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `UQ_libary_user_username` (`username`),
   CONSTRAINT `CHK_libary_user_username_not_empty` CHECK (char_length(`username`) > 0)
@@ -49,6 +50,7 @@ CREATE TABLE IF NOT EXISTS `book` (
   `isbn` varchar(20) NOT NULL,
   `topic` varchar(50) NOT NULL,
   `location` varchar(20) NOT NULL,
+  `deleted` tinyint(1) DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `FK_book_library_user` (`library_user`),
   CONSTRAINT `FK_book_library_user` FOREIGN KEY (`library_user`) REFERENCES `library_user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE

--- a/src/queries/book.ts
+++ b/src/queries/book.ts
@@ -17,13 +17,22 @@ const querySelectAllBooks = async (): Promise<Book[]> => {
     return rows as Book[];
 };
 
-const queryDeleteBook = async (bookId: number): Promise<boolean> => {
+const queryHardDeleteBook = async (bookId: number): Promise<boolean> => {
     const promisePool = pool.promise();
     const [rows] = await promisePool.query<ResultSetHeader>(
         "DELETE FROM book WHERE id=?",
         [bookId]
     );
     return rows.affectedRows != 0;
+};
+
+const querySoftDeleteBook = async (bookId: number): Promise<boolean> => {
+    const promisePool = pool.promise();
+    const [rows] = await promisePool.query<ResultSetHeader>(
+        "UPDATE book SET deleted=1 WHERE id=(?)",
+        [bookId]
+    );
+    return rows.changedRows != 0;
 };
 
 const queryInsertBook = async (
@@ -54,7 +63,8 @@ const queryUpdateBook = async (book: Book): Promise<boolean> => {
 export {
     querySelectBook,
     querySelectAllBooks,
-    queryDeleteBook,
+    queryHardDeleteBook,
+    querySoftDeleteBook,
     queryInsertBook,
     queryUpdateBook,
 };

--- a/src/queries/user.ts
+++ b/src/queries/user.ts
@@ -39,10 +39,19 @@ const querySelectUserByUsername = async (
     return rows.length > 0 ? (rows[0] as User) : null;
 };
 
-const queryDeleteUser = async (userId: number): Promise<boolean> => {
+const queryHardDeleteUser = async (userId: number): Promise<boolean> => {
     const promisePool = pool.promise();
     const [rows] = await promisePool.query<ResultSetHeader>(
         "DELETE FROM library_user WHERE id = ?",
+        [userId]
+    );
+    return rows.affectedRows != 0;
+};
+
+const querySoftDeleteUser = async (userId: number): Promise<boolean> => {
+    const promisePool = pool.promise();
+    const [rows] = await promisePool.query<ResultSetHeader>(
+        "UPDATE library_user SET deleted=1 WHERE id=(?)",
         [userId]
     );
     return rows.affectedRows != 0;
@@ -81,7 +90,8 @@ export {
     querySelectUser,
     querySelectUserBySessionId,
     querySelectUserByUsername,
-    queryDeleteUser,
+    querySoftDeleteUser,
+    queryHardDeleteUser,
     queryInsertUser,
     queryUpdateUser,
 };

--- a/src/routes/book.ts
+++ b/src/routes/book.ts
@@ -2,7 +2,7 @@ import { Response, Request, Router, NextFunction } from "express";
 import {
     querySelectBook,
     querySelectAllBooks,
-    queryDeleteBook,
+    querySoftDeleteBook,
     queryInsertBook,
     queryUpdateBook,
 } from "../queries/book";
@@ -34,7 +34,7 @@ router.delete("/", async (req: Request, res: Response, next: NextFunction) => {
             (req.sessionUser.id == book.library_user ||
                 req.sessionUser.administrator)
         ) {
-            res.json({ ok: await queryDeleteBook(book.id) });
+            res.json({ ok: await querySoftDeleteBook(book.id) });
         } else {
             res.status(403).json({ ok: false });
         }

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -2,7 +2,7 @@ import { Response, Request, Router, NextFunction } from "express";
 import {
     querySelectAllUsers,
     querySelectUser,
-    queryDeleteUser,
+    querySoftDeleteUser,
     queryInsertUser,
     queryUpdateUser,
 } from "../queries/user";
@@ -58,7 +58,7 @@ router.get(
 router.delete("/", async (req: Request, res: Response, next: NextFunction) => {
     try {
         if (req.sessionUser.administrator) {
-            res.json({ ok: await queryDeleteUser(Number(req.body.id)) });
+            res.json({ ok: await querySoftDeleteUser(Number(req.body.id)) });
         } else {
             res.status(403).json({ ok: false });
         }


### PR DESCRIPTION
Delete endpoint for /book and /user changed to use a soft delete instead of a hard one by default, so queries will now UPDATE "deleted" value to 1 instead of making a DELETE query. 