### PR TITLE
commit auth borrow after the fix

### DIFF
--- a/src/routes/borrow.ts
+++ b/src/routes/borrow.ts
@@ -33,10 +33,19 @@ router.get("/", async (req: Request, res: Response, next: NextFunction) => {
 
 router.delete("/", async (req: Request, res: Response, next: NextFunction) => {
     try {
-        res.json({ ok: await queryDeleteBorrow(Number(req.query.id)) });
+        const borrow = await querySelectBorrow(req.body.borrowId);
+        if (
+            borrow &&
+            (borrow.library_user == req.sessionUser.id ||
+                req.sessionUser.administrator)
+        ) {
+            res.json({ ok: await queryDeleteBorrow(Number(req.query.borrowId)) });
+        } else {
+            res.status(403).json({ ok: false });
+        }
     } catch (err) {
         next(err);
-    }
+    };
 });
 
 router.post("/", async (req: Request, res: Response, next: NextFunction) => {


### PR DESCRIPTION
router.delete and two router.put were rewritten to fit the latest fix. 
If the user is an owner of a borrowed book or if the user is an admin, they are allowed to change/return the book accordingly. If not, will send an error message.