### PR TITLE
Returing borrow id's when requesting detailedExpiredBorrows

### DIFF
--- a/src/interfaces/detailedExpiredBorrows.interface.ts
+++ b/src/interfaces/detailedExpiredBorrows.interface.ts
@@ -1,4 +1,5 @@
 interface DetailedExpiredBorrow {
+    borrowId: number;
     title: string;
     dueDate: Date;
     bookId: number;

--- a/src/queries/borrow.ts
+++ b/src/queries/borrow.ts
@@ -113,7 +113,7 @@ export const queryDetailedExpiredBorrows = async (): Promise<
 > => {
     const promisePool = pool.promise();
     const [rows] = await promisePool.query<RowDataPacket[]>(
-        "SELECT borrowing.dueDate, book.title, book.id AS bookId, library_user.username, library_user.id AS userId FROM borrowing JOIN library_user ON library_user.id = borrowing.library_user JOIN book ON book.id= borrowing.book WHERE borrowing.dueDate < now() AND borrowing.returned = 0;"
+        "SELECT borrowing.id AS borrowId, borrowing.dueDate, book.title, book.id AS bookId, library_user.username, library_user.id AS userId FROM borrowing JOIN library_user ON library_user.id = borrowing.library_user JOIN book ON book.id= borrowing.book WHERE borrowing.dueDate < now() AND borrowing.returned = 0;"
     );
     return rows as DetailedExpiredBorrow[];
 };


### PR DESCRIPTION
So MUI data grid needs unique id's for grid components. With interfaces it's better to have borrow id's sent from backend