### PR TITLE
fix: user password set as an empty string on PUT /user

### DIFF
--- a/src/queries/user.ts
+++ b/src/queries/user.ts
@@ -86,8 +86,16 @@ export const queryInsertUser = async (
     };
 };
 
-// Will not update password.
 export const queryUpdateUser = async (user: User): Promise<boolean> => {
+    const promisePool = pool.promise();
+    const [rows] = await promisePool.query<ResultSetHeader>(
+        "UPDATE library_user SET username=(?), passw=(?), administrator=(?) WHERE id=(?)",
+        [user.username, user.passw, user.administrator, user.id]
+    );
+    return rows.affectedRows != 0;
+};
+
+export const queryAdminUpdateUser = async (user: User): Promise<boolean> => {
     const promisePool = pool.promise();
     const [rows] = await promisePool.query<ResultSetHeader>(
         "UPDATE library_user SET username=(?), administrator=(?) WHERE id=(?)",

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -5,6 +5,7 @@ import {
     querySoftDeleteUser,
     queryInsertUser,
     queryUpdateUser,
+    queryAdminUpdateUser,
 } from "../queries/user";
 import User from "../interfaces/user.interface";
 
@@ -91,7 +92,6 @@ router.post("/", async (req: Request, res: Response, next: NextFunction) => {
     }
 });
 
-// Password isn't always sent from frontend. Separate endpoint for password update?
 router.put("/", async (req: Request, res: Response, next: NextFunction) => {
     try {
         if (req.sessionUser.administrator) {
@@ -111,5 +111,29 @@ router.put("/", async (req: Request, res: Response, next: NextFunction) => {
         next(err);
     }
 });
+
+router.put(
+    "/admin",
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            if (req.sessionUser.administrator) {
+                // Another new interface for this?
+                const user: User = {
+                    id: Number(req.query.id),
+                    username: req.query.username as string,
+                    passw: "null",
+                    administrator:
+                        req.query.administrator === "true" ? true : false,
+                    deleted: false,
+                };
+                res.json({ ok: await queryAdminUpdateUser(user) });
+            } else {
+                res.status(403).json({ ok: false });
+            }
+        } catch (err) {
+            next(err);
+        }
+    }
+);
 
 export default router;


### PR DESCRIPTION
When updating user on adminPage in frontend, password isn't sent in a PUT request, so backend would update the password as an empty string