### PR TITLE
Add uncaught exception handler to make sure application doesn't randomly exit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,15 @@ declare global {
   }
 }
 
+process.on("uncaughtException", (err, origin) => {
+  console.log(
+    `[UNCAUGHT EXCEPTION] at ${new Date().toISOString()}:\n`,
+    err,
+    "\nUncaught exception origin:\n",
+    origin
+  );
+});
+
 const app: Express = express();
 app.use(express.json());
 app.use(cors({ credentials: true, origin: true }));


### PR DESCRIPTION
To test:

Example for when the crash happens:
- Start backend without starting MySQL or having an invalid MySQL configuration
- Press the login button
- The backend crashes

Reattempting to do this with the current branch doesn't crash the application.