### PR TITLE
#136  unique session secrets

### DIFF
--- a/sql/02_sessions.sql
+++ b/sql/02_sessions.sql
@@ -3,7 +3,7 @@ USE `efilibrarydb`;
 CREATE TABLE IF NOT EXISTS `sessions` (
     `id` int(11) NOT NULL AUTO_INCREMENT,
     `userId` int(11) NOT NULL,
-    `secret` VARCHAR(32) NOT NULL,
+    `secret` VARCHAR(255) NOT NULL,
     `expires` int(11) NOT NULL,
     `invalidated` int(1) NOT NULL DEFAULT 0,
     PRIMARY KEY (`id`),

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -17,8 +17,7 @@ const maxPasswordLength = 150;
 const router = Router();
 
 export async function createSession(userId: number) {
-  // TODO: Secret should be unique but duplicates shouldn't really cause any issues
-  let secret = crypto.randomBytes(16).toString("hex");
+  let secret = crypto.randomUUID();
   return await queryInsertSession(userId, secret, timeout);
 }
 


### PR DESCRIPTION
#136 requires rebuilding of the database. (the new secret is longer than what is allowed in the original session table)